### PR TITLE
Enhance Safe Time scheduler UI

### DIFF
--- a/SafeTimeManager.swift
+++ b/SafeTimeManager.swift
@@ -55,11 +55,18 @@ class SafeTimeManager: ObservableObject {
         return Int(ceil(remaining / 86_400))
     }
 
-    /// Persists new safe time hours and records the last update timestamp.
-    func setSafeTime(start: Date, end: Date) {
+    /// Updates the start/end hours and active days while tracking the last
+    /// modification date. This enforces the one-change-per-week rule.
+    func updateSafeSchedule(start: Date, end: Date, days: [Int]) {
         safeStartHour = Calendar.current.component(.hour, from: start)
         safeEndHour = Calendar.current.component(.hour, from: end)
+        safeDays = days
         lastSafeTimeUpdate = Date().timeIntervalSince1970
+    }
+
+    /// Persists new safe time hours using the existing active days.
+    func setSafeTime(start: Date, end: Date) {
+        updateSafeSchedule(start: start, end: end, days: safeDays)
     }
 
     var isInSafeTime: Bool {

--- a/SafeTimeSettingsView.swift
+++ b/SafeTimeSettingsView.swift
@@ -1,27 +1,50 @@
 import SwiftUI
 
+/// Screen for configuring the "Safe Time" schedule when phone usage
+/// should not incur charges. Users choose a daily start and end time as
+/// well as the days of the week the window applies to.
 struct SafeTimeSettingsView: View {
+    /// Provides access to persisted safe time information.
     @ObservedObject var safeTimeManager: SafeTimeManager
+    /// The currently chosen start time.
     @State private var selectedStart = Date()
+    /// The currently chosen end time.
     @State private var selectedEnd = Date().addingTimeInterval(3600)
+    /// The days of the week the safe window is active (1 = Sunday).
+    @State private var selectedDays: Set<Int> = []
 
     var body: some View {
         NavigationView {
             Form {
+                // Pick the hours during which usage is free
                 Section(header: Text("Select your Safe Time Window")) {
                     DatePicker("Start Time", selection: $selectedStart, displayedComponents: .hourAndMinute)
+                        .disabled(!safeTimeManager.canUpdateSafeTime)
                     DatePicker("End Time", selection: $selectedEnd, displayedComponents: .hourAndMinute)
+                        .disabled(!safeTimeManager.canUpdateSafeTime)
                 }
 
+                // Choose which weekdays the window is active using a compact calendar
+                Section(header: Text("Active Days")) {
+                    WeekdayCalendarPicker(selection: $selectedDays,
+                                          disabled: !safeTimeManager.canUpdateSafeTime)
+                }
+
+                // Button to persist selections
                 Section {
                     Button("Save Safe Time") {
-                        safeTimeManager.setSafeTime(start: selectedStart, end: selectedEnd)
+                        safeTimeManager.updateSafeSchedule(
+                            start: selectedStart,
+                            end: selectedEnd,
+                            days: Array(selectedDays).sorted()
+                        )
                     }
                     .disabled(!safeTimeManager.canUpdateSafeTime)
                 }
 
                 if !safeTimeManager.canUpdateSafeTime {
-                    Text("You can update your safe time again in \(safeTimeManager.remainingDays) days.")
+                    // Show a notice when edits are locked
+                    Text("You can update your safe time again in \(safeTimeManager.remainingDays) days. Changes are allowed once every 7 days.")
                         .font(.footnote)
                         .foregroundColor(.gray)
                 }
@@ -29,8 +52,10 @@ struct SafeTimeSettingsView: View {
             .navigationBarTitle("Safe Time Settings")
         }
         .onAppear {
+            // Populate selections with previously saved values
             selectedStart = safeTimeManager.safeStart
             selectedEnd = safeTimeManager.safeEnd
+            selectedDays = Set(safeTimeManager.safeDays)
         }
     }
 }

--- a/WeekdayCalendarPicker.swift
+++ b/WeekdayCalendarPicker.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// A compact calendar-like control for toggling the days a schedule is active.
+struct WeekdayCalendarPicker: View {
+    /// Bound set of selected weekday numbers (1 = Sunday).
+    @Binding var selection: Set<Int>
+    /// Whether user interactions are disabled.
+    var disabled: Bool = false
+
+    private let columns = Array(repeating: GridItem(.flexible()), count: 7)
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(1...7, id: \.self) { day in
+                let symbol = Calendar.current.shortWeekdaySymbols[day - 1]
+                Button(action: {
+                    toggle(day)
+                }) {
+                    Text(symbol)
+                        .frame(maxWidth: .infinity, minHeight: 32)
+                        .padding(4)
+                        .background(selection.contains(day) ? Color.blue.opacity(0.2) : Color.clear)
+                        .cornerRadius(6)
+                }
+                .buttonStyle(.plain)
+                .disabled(disabled)
+            }
+        }
+    }
+
+    private func toggle(_ day: Int) {
+        if selection.contains(day) {
+            selection.remove(day)
+        } else {
+            selection.insert(day)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `WeekdayCalendarPicker` view for calendar-style selection
- update `SafeTimeManager` to save schedule and enforce weekly change rule
- integrate new picker in `SafeTimeSettingsView`
- show rule reminder when schedule edits are locked

## Testing
- `swiftc SafeTimeSettingsView.swift` *(fails: no such module 'SwiftUI')*
- `swiftc SafeTimeManager.swift` *(fails: no such module 'SwiftUI')*
- `swiftc WeekdayCalendarPicker.swift` *(fails: no such module 'SwiftUI')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6860cdc85c908324aae4f3689052b5af