### PR TITLE
Track safe time change date

### DIFF
--- a/SafeTimeSettingsView.swift
+++ b/SafeTimeSettingsView.swift
@@ -7,6 +7,15 @@ struct SafeTimeSettingsView: View {
     /// Provides access to persisted safe time information.
     @ObservedObject var safeTimeManager: SafeTimeManager
 
+    /// Tracks when the safe time was last changed.
+    @AppStorage("lastSafeTimeChangeDate") private var lastSafeTimeChangeDate: Double = 0
+
+    /// Whether at least seven days have passed since the last change.
+    private var sevenDaysSinceChange: Bool {
+        let elapsed = Date().timeIntervalSince1970 - lastSafeTimeChangeDate
+        return elapsed >= 7 * 86_400
+    }
+
     /// The currently chosen start time.
     @State private var selectedStart = Date()
     /// The currently chosen end time.
@@ -56,6 +65,7 @@ struct SafeTimeSettingsView: View {
                         end: selectedEnd,
                         days: Array(selectedDays).sorted()
                     )
+                    lastSafeTimeChangeDate = Date().timeIntervalSince1970
                 }
                 Button("Cancel", role: .cancel) {}
             } message: {


### PR DESCRIPTION
## Summary
- track the last time the Safe Time settings were modified
- provide a helper checking if seven days have elapsed since that date
- update the timestamp when saving

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68619c7a00b083249a93bd1806d6d0e0