### PR TITLE
Disable app use when outside safe time

### DIFF
--- a/AppCardView.swift
+++ b/AppCardView.swift
@@ -4,6 +4,8 @@ struct AppCardView: View {
     let appName: String
     let timeUsed: Int
     let limit: Int
+    /// Whether the start button should be disabled.
+    let isDisabled: Bool
     let onStart: () -> Void
 
     var percentUsed: Double {
@@ -17,6 +19,11 @@ struct AppCardView: View {
         case 0.7..<1.0: return .yellow
         default: return .red
         }
+    }
+
+    /// The color of the start button depending on the disabled state.
+    var buttonColor: Color {
+        isDisabled ? Color.gray.opacity(0.5) : usageColor.opacity(0.8)
     }
 
     var body: some View {
@@ -49,10 +56,11 @@ struct AppCardView: View {
                         .font(.subheadline)
                         .padding(.horizontal, 16)
                         .padding(.vertical, 8)
-                        .background(usageColor.opacity(0.8))
+                        .background(buttonColor)
                         .foregroundColor(.white)
                         .clipShape(Capsule())
                 }
+                .disabled(isDisabled)
             }
             .padding()
         }

--- a/MainAppView.swift
+++ b/MainAppView.swift
@@ -36,20 +36,24 @@ struct MainAppView: View {
                 .font(.headline)
 
                 ForEach(apps, id: \.self) { app in
+                    let limitReached = (appSessions[app] ?? 0) >= (appLimits[app] ?? 0)
+                    let disableApp = !isInSafeTime && limitReached
+
                     AppCardView(
                         appName: app,
-                            timeUsed: appSessions[app] ?? 0,
-                            limit: appLimits[app] ?? 0
-                        ) {
-                            if (appSessions[app] ?? 0) >= (appLimits[app] ?? 0) {
-                                selectedApp = app
-                                showPaywall = true
-                            } else {
-                                appSessions[app, default: 0] += 1
-                                saveAppSessions()
-                            }
+                        timeUsed: appSessions[app] ?? 0,
+                        limit: appLimits[app] ?? 0,
+                        isDisabled: disableApp
+                    ) {
+                        if limitReached {
+                            selectedApp = app
+                            showPaywall = true
+                        } else {
+                            appSessions[app, default: 0] += 1
+                            saveAppSessions()
                         }
                     }
+                }
                 }
                 .padding()
             }


### PR DESCRIPTION
## Summary
- add disabled state support to `AppCardView`
- disable app buttons when outside the user's safe time and they've hit the limit

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68619f48d3f083248436faef4dc459cf