### PR TITLE
Handle taps on apps outside Safe Time

### DIFF
--- a/MainAppView.swift
+++ b/MainAppView.swift
@@ -37,15 +37,14 @@ struct MainAppView: View {
 
                 ForEach(apps, id: \.self) { app in
                     let limitReached = (appSessions[app] ?? 0) >= (appLimits[app] ?? 0)
-                    let disableApp = !isInSafeTime && limitReached
 
                     AppCardView(
                         appName: app,
                         timeUsed: appSessions[app] ?? 0,
                         limit: appLimits[app] ?? 0,
-                        isDisabled: disableApp
+                        isDisabled: false
                     ) {
-                        if limitReached {
+                        if !isInSafeTime || limitReached {
                             selectedApp = app
                             showPaywall = true
                         } else {


### PR DESCRIPTION
## Summary
- show paywall when an app is tapped outside the Safe Time window

## Testing
- `swift --version`
- `swiftc MainAppView.swift -o /tmp/mainapp` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6861a03adde08324934caef633848bc6