### PR TITLE
Add persistent onboarding flow

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -2,16 +2,14 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var showOnboarding = true
+    @AppStorage("onboardingCompleted") private var onboardingCompleted = false
     @StateObject private var store = StoreManager()
 
     var body: some View {
-        if showOnboarding {
-            OnboardingView {
-                showOnboarding = false
-            }
-        } else {
+        if onboardingCompleted {
             MainAppView(store: store)
+        } else {
+            OnboardingView()
         }
     }
 }

--- a/OnboardingView.swift
+++ b/OnboardingView.swift
@@ -2,7 +2,7 @@
 import SwiftUI
 
 struct OnboardingView: View {
-    let onFinish: () -> Void
+    @AppStorage("onboardingCompleted") private var onboardingCompleted = false
     @State private var pageIndex = 0
 
     var body: some View {
@@ -59,8 +59,10 @@ struct OnboardingView: View {
                     .multilineTextAlignment(.center)
                     .padding(.horizontal)
 
-                Button(action: onFinish) {
-                    Text("Continue")
+                Button(action: {
+                    onboardingCompleted = true
+                }) {
+                    Text("Get Started")
                         .font(.system(size: 22, weight: .bold))
                         .padding()
                         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- update onboarding view to store completion state in `AppStorage`
- show `OnboardingView` only when onboarding has not been completed
- replace final onboarding button with **Get Started** to mark completion

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6861a1706bac8324b7ae9043e10f08af