### PR TITLE
Add notification permission request

### DIFF
--- a/NotificationManager.swift
+++ b/NotificationManager.swift
@@ -1,0 +1,16 @@
+import Foundation
+import UserNotifications
+
+class NotificationManager {
+    static let shared = NotificationManager()
+
+    func requestAuthorization() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            if let error = error {
+                print("Notification authorization error: \(error.localizedDescription)")
+            } else {
+                print("Notification permission granted: \(granted)")
+            }
+        }
+    }
+}

--- a/Time_is_MoneyApp.swift
+++ b/Time_is_MoneyApp.swift
@@ -1,7 +1,11 @@
 import SwiftUI
 
+/// The main entry point of the app. Requests notification permissions on launch.
 @main
 struct Time_is_MoneyApp: App {
+    init() {
+        NotificationManager.shared.requestAuthorization()
+    }
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
## Summary
- add a `NotificationManager` for requesting notification permissions
- request permissions when the app starts

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_6861abe065ac8324afa148121ee521e7