### PR TITLE
Add notifications for safe time and limits

### DIFF
--- a/MainAppView.swift
+++ b/MainAppView.swift
@@ -48,8 +48,19 @@ struct MainAppView: View {
                             selectedApp = app
                             showPaywall = true
                         } else {
-                            appSessions[app, default: 0] += 1
+                            let newUsage = (appSessions[app] ?? 0) + 1
+                            appSessions[app] = newUsage
                             saveAppSessions()
+
+                            let limit = appLimits[app] ?? 0
+                            if limit > 0 {
+                                if newUsage == limit / 2 {
+                                    NotificationManager.shared.notifyHalfLimitReached(for: app)
+                                }
+                                if newUsage == limit {
+                                    NotificationManager.shared.notifyLimitReached(for: app)
+                                }
+                            }
                         }
                     }
                 }

--- a/NotificationManager.swift
+++ b/NotificationManager.swift
@@ -13,4 +13,60 @@ class NotificationManager {
             }
         }
     }
+
+    /// Schedules a repeating notification 5 minutes before the Safe Time window
+    /// ends on the given weekdays.
+    func scheduleSafeTimeEndReminder(endHour: Int, days: [Int]) {
+        let center = UNUserNotificationCenter.current()
+
+        // Remove any existing Safe Time notifications
+        let ids = (1...7).map { "safeTimeEnd-\($0)" }
+        center.removePendingNotificationRequests(withIdentifiers: ids)
+
+        let calendar = Calendar.current
+        for day in days {
+            var comps = DateComponents()
+            comps.weekday = day
+            comps.hour = endHour
+            comps.minute = 0
+
+            guard let next = calendar.nextDate(after: Date(), matching: comps, matchingPolicy: .nextTimePreservingSmallerComponents),
+                  let triggerDate = calendar.date(byAdding: .minute, value: -5, to: next) else { continue }
+
+            let triggerComps = calendar.dateComponents([.weekday, .hour, .minute], from: triggerDate)
+
+            let content = UNMutableNotificationContent()
+            content.title = "Safe Time Ending Soon"
+            content.body = "Your Safe Time ends in 5 minutes."
+            content.sound = .default
+
+            let trigger = UNCalendarNotificationTrigger(dateMatching: triggerComps, repeats: true)
+            let request = UNNotificationRequest(identifier: "safeTimeEnd-\(day)", content: content, trigger: trigger)
+            center.add(request)
+        }
+    }
+
+    /// Immediately delivers a notification that the user has reached half of
+    /// their daily limit for the given app.
+    func notifyHalfLimitReached(for app: String) {
+        scheduleImmediate(title: "Halfway There", body: "You've used half of your \(app) limit today.")
+    }
+
+    /// Immediately delivers a notification that the daily limit for the given
+    /// app has been reached.
+    func notifyLimitReached(for app: String) {
+        scheduleImmediate(title: "Limit Reached", body: "You've reached your daily \(app) limit.")
+    }
+
+    /// Helper to schedule a notification firing almost immediately.
+    private func scheduleImmediate(title: String, body: String) {
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)
+        UNUserNotificationCenter.current().add(request)
+    }
 }

--- a/SafeTimeManager.swift
+++ b/SafeTimeManager.swift
@@ -11,6 +11,10 @@ class SafeTimeManager: ObservableObject {
     private let minDaysBetweenUpdates = 7
 
     @Published var currentDate = Date()
+
+    init() {
+        NotificationManager.shared.scheduleSafeTimeEndReminder(endHour: safeEndHour, days: safeDays)
+    }
     
     var safeDays: [Int] {
         get {
@@ -62,6 +66,7 @@ class SafeTimeManager: ObservableObject {
         safeEndHour = Calendar.current.component(.hour, from: end)
         safeDays = days
         lastSafeTimeUpdate = Date().timeIntervalSince1970
+        NotificationManager.shared.scheduleSafeTimeEndReminder(endHour: safeEndHour, days: safeDays)
     }
 
     /// Persists new safe time hours using the existing active days.


### PR DESCRIPTION
## Summary
- add helper methods to schedule local notifications
- fire a notification 5 minutes before Safe Time ends for selected days
- show alerts when app limits hit halfway and full usage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861b0a9d2708324995e26c80d3cc817