### PR TITLE
Add haptic feedback for button interactions

### DIFF
--- a/ActivationScreen.swift
+++ b/ActivationScreen.swift
@@ -39,6 +39,7 @@ struct ActivationScreen: View {
                 .cornerRadius(12)
 
                 Button("Activate") {
+                    HapticManager.tap()
                     if let url = URL(string: "https://time-is-money-fd03d.web.app/profile-download.html") {
                         UIApplication.shared.open(url)
                     }

--- a/AppCardView.swift
+++ b/AppCardView.swift
@@ -51,7 +51,10 @@ struct AppCardView: View {
 
                 Spacer()
 
-                Button(action: onStart) {
+                Button(action: {
+                    HapticManager.tap()
+                    onStart()
+                }) {
                     Text("Start")
                         .font(.subheadline)
                         .padding(.horizontal, 16)

--- a/AppLimitSettingsView.swift
+++ b/AppLimitSettingsView.swift
@@ -40,7 +40,9 @@ struct AppLimitSettingsView: View {
             }
 
             Button("Save Limits") {
+                HapticManager.tap()
                 saveLimits()
+                HapticManager.success()
                 showDonationPriceScreen = true
             }
             .padding()

--- a/DonationPriceSettingsView.swift
+++ b/DonationPriceSettingsView.swift
@@ -35,7 +35,9 @@ struct DonationPriceSettingsView: View {
             }
 
             Button("Confirm Donation Amount") {
+                HapticManager.tap()
                 presentationMode.wrappedValue.dismiss()
+                HapticManager.success()
             }
             .padding()
             .frame(maxWidth: .infinity)

--- a/HapticManager.swift
+++ b/HapticManager.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+enum HapticManager {
+    /// Light impact for generic button taps.
+    static func tap() {
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+
+    /// Success notification haptic feedback.
+    static func success() {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(.success)
+    }
+}

--- a/InstallProfileInstructionsView.swift
+++ b/InstallProfileInstructionsView.swift
@@ -33,6 +33,7 @@ struct InstallProfileInstructionsView: View {
             .padding(.horizontal)
 
             Button(action: {
+                HapticManager.tap()
                 if let url = URL(string: "https://time-is-money-fd03d.web.app/profile-download.html") {
                     UIApplication.shared.open(url)
                 }
@@ -48,7 +49,9 @@ struct InstallProfileInstructionsView: View {
             .padding(.horizontal)
 
             Button(action: {
+                HapticManager.tap()
                 profileInstalled = true
+                HapticManager.success()
             }) {
                 Text("Continue")
                     .font(.headline)

--- a/LimitSetterView.swift
+++ b/LimitSetterView.swift
@@ -29,7 +29,9 @@ struct LimitSetterView: View {
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
+                        HapticManager.tap()
                         saveAppLimits()
+                        HapticManager.success()
                     }
                 }
             }

--- a/MainAppView.swift
+++ b/MainAppView.swift
@@ -31,6 +31,7 @@ struct MainAppView: View {
                     .padding(.top, 20)
 
                 Button("Safe Time Settings") {
+                    HapticManager.tap()
                     showSafeTimeSettings = true
                 }
                 .font(.headline)
@@ -77,6 +78,7 @@ struct MainAppView: View {
                 PaywallView(appName: app, onUnlock: {
                     appSessions[app, default: 0] += bonusTime(for: app)
                     saveAppSessions()
+                    HapticManager.success()
                     showPaywall = false
                 }, store: store)
             }

--- a/OnboardingView.swift
+++ b/OnboardingView.swift
@@ -13,7 +13,10 @@ struct OnboardingView: View {
                     .bold()
                     .multilineTextAlignment(.center)
 
-                Button(action: { pageIndex += 1 }) {
+                Button(action: {
+                    HapticManager.tap()
+                    pageIndex += 1
+                }) {
                     Text("Continue")
                         .font(.system(size: 22, weight: .bold))
                         .padding()
@@ -33,7 +36,10 @@ struct OnboardingView: View {
                     .multilineTextAlignment(.center)
                     .padding()
 
-                Button(action: { pageIndex += 1 }) {
+                Button(action: {
+                    HapticManager.tap()
+                    pageIndex += 1
+                }) {
                     Text("Continue")
                         .font(.system(size: 22, weight: .bold))
                         .padding()
@@ -60,7 +66,9 @@ struct OnboardingView: View {
                     .padding(.horizontal)
 
                 Button(action: {
+                    HapticManager.tap()
                     onboardingCompleted = true
+                    HapticManager.success()
                 }) {
                     Text("Get Started")
                         .font(.system(size: 22, weight: .bold))

--- a/PaywallView.swift
+++ b/PaywallView.swift
@@ -29,6 +29,7 @@ struct PaywallView: View {
                 }
 
                 Button("Cancel") {
+                    HapticManager.tap()
                     dismiss()
                 }
                 .foregroundColor(.red)
@@ -46,9 +47,11 @@ struct PaywallView: View {
             VStack(spacing: 20) {
                 ForEach(store.products, id: \.id) { product in
                     DonationProductButton(product: product) {
+                        HapticManager.tap()
                         Task {
-                            let success = await store.purchase(product) // 🔧 FIXED THIS LINE
+                            let success = await store.purchase(product)
                             if success {
+                                HapticManager.success()
                                 onUnlock()
                             }
                         }

--- a/SafeTimeSettingsView.swift
+++ b/SafeTimeSettingsView.swift
@@ -49,6 +49,7 @@ struct SafeTimeSettingsView: View {
                 // Button to persist selections
                 Section {
                     Button("Save Safe Time") {
+                        HapticManager.tap()
                         showConfirm = true
                     }
                     .disabled(!safeTimeManager.canUpdateSafeTime)
@@ -64,6 +65,7 @@ struct SafeTimeSettingsView: View {
             .navigationBarTitle("Safe Time Settings")
             .alert("Save Safe Time?", isPresented: $showConfirm) {
                 Button("Confirm") {
+                    HapticManager.tap()
                     safeTimeManager.updateSafeSchedule(
                         start: selectedStart,
                         end: selectedEnd,
@@ -72,8 +74,9 @@ struct SafeTimeSettingsView: View {
                     safeStartTime = selectedStart.timeIntervalSince1970
                     safeEndTime = selectedEnd.timeIntervalSince1970
                     lastSafeTimeChangeDate = Date().timeIntervalSince1970
+                    HapticManager.success()
                 }
-                Button("Cancel", role: .cancel) {}
+                Button("Cancel", role: .cancel) { HapticManager.tap() }
             } message: {
                 Text("This change will be locked for 7 days. Are you sure?")
             }

--- a/SessionView.swift
+++ b/SessionView.swift
@@ -34,6 +34,7 @@ struct SessionView: View {
                     .padding()
 
                 Button("End Session") {
+                    HapticManager.tap()
                     sessionActive = false
                     dismiss()
                 }

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -11,15 +11,20 @@ struct SettingsView: View {
             List {
                 Section(header: Text("Reset")) {
                     Button("Reset All App Limits") {
+                        HapticManager.tap()
                         onResetLimits()
+                        HapticManager.success()
                     }
                     Button("Reset All App Sessions") {
+                        HapticManager.tap()
                         onResetSessions()
+                        HapticManager.success()
                     }
                 }
 
                 Section(header: Text("Onboarding")) {
                     Button("See Onboarding Again") {
+                        HapticManager.tap()
                         onRecallOnboarding()
                     }
                 }
@@ -35,6 +40,7 @@ struct SettingsView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Close") {
+                        HapticManager.tap()
                         isPresented = false
                     }
                 }

--- a/WeekdayCalendarPicker.swift
+++ b/WeekdayCalendarPicker.swift
@@ -14,6 +14,7 @@ struct WeekdayCalendarPicker: View {
             ForEach(1...7, id: \.self) { day in
                 let symbol = Calendar.current.shortWeekdaySymbols[day - 1]
                 Button(action: {
+                    HapticManager.tap()
                     toggle(day)
                 }) {
                     Text(symbol)


### PR DESCRIPTION
## Summary
- create `HapticManager` for common feedback helpers
- trigger light feedback on button taps
- play success haptics when purchases complete or settings are saved

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6861b4c5aa9883248ed8f0a87f618e9f