### PR TITLE
Add transition animation for app start

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -6,10 +6,15 @@ struct ContentView: View {
     @StateObject private var store = StoreManager()
 
     var body: some View {
-        if !onboardingCompleted {
-            OnboardingView()
-        } else {
-            MainAppView(store: store)
+        ZStack {
+            if onboardingCompleted {
+                MainAppView(store: store)
+                    .transition(.move(edge: .trailing))
+            } else {
+                OnboardingView()
+                    .transition(.move(edge: .trailing))
+            }
         }
+        .animation(.easeInOut, value: onboardingCompleted)
     }
 }


### PR DESCRIPTION
## Summary
- animate switch between onboarding and main app screens

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6861d9532a588324bc71810b521a46a1