### PR TITLE
Introduce FontTheme for consistent typography

### DIFF
--- a/ActivationScreen.swift
+++ b/ActivationScreen.swift
@@ -19,11 +19,11 @@ struct ActivationScreen: View {
 
             VStack(spacing: 26) {
                 Text("Let’s Finish Setup")
-                    .font(.system(size: 32, weight: .bold, design: .rounded))
+                    .font(FontTheme.titleFont)
                     .multilineTextAlignment(.center)
 
                 Text("Just one step left: install the permission from Safari so we can enforce screen time limits.")
-                    .font(.body)
+                    .font(FontTheme.bodyFont)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal)
 
@@ -33,7 +33,7 @@ struct ActivationScreen: View {
                     Text("3. Tap 'Allow' when prompted")
                     Text("4. Go to Settings > Profile Downloaded to install")
                 }
-                .font(.system(size: 18, weight: .regular, design: .rounded))
+                .font(FontTheme.bodyFont)
                 .padding()
                 .background(.ultraThinMaterial)
                 .cornerRadius(12)

--- a/AppCardView.swift
+++ b/AppCardView.swift
@@ -44,7 +44,7 @@ struct AppCardView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(appName)
-                        .font(.system(size: 20, weight: .semibold, design: .rounded))
+                        .font(FontTheme.subtitleFont)
                     ProgressView(value: percentUsed)
                         .progressViewStyle(LinearProgressViewStyle(tint: usageColor))
                 }

--- a/AppLimitSettingsView.swift
+++ b/AppLimitSettingsView.swift
@@ -16,7 +16,7 @@ struct AppLimitSettingsView: View {
     var body: some View {
         VStack(spacing: 20) {
             Text("Set Daily Limits")
-                .font(.largeTitle)
+                .font(FontTheme.titleFont)
                 .bold()
                 .padding(.top)
 
@@ -24,7 +24,7 @@ struct AppLimitSettingsView: View {
                 ForEach(appLimits.keys.sorted(), id: \.self) { app in
                     VStack(alignment: .leading) {
                         Text(app)
-                            .font(.headline)
+                            .font(FontTheme.subtitleFont)
 
                         Slider(value: Binding(
                             get: { Double(appLimits[app] ?? 0) },
@@ -32,7 +32,7 @@ struct AppLimitSettingsView: View {
                         ), in: 0...120, step: 5)
 
                         Text("\(appLimits[app] ?? 0) minutes")
-                            .font(.caption)
+                            .font(FontTheme.bodyFont)
                             .foregroundColor(.gray)
                     }
                     .padding(.vertical, 5)

--- a/DonationPriceSettingsView.swift
+++ b/DonationPriceSettingsView.swift
@@ -9,12 +9,12 @@ struct DonationPriceSettingsView: View {
     var body: some View {
         VStack(spacing: 30) {
             Text("Set Donation Price")
-                .font(.largeTitle)
+                .font(FontTheme.titleFont)
                 .bold()
                 .multilineTextAlignment(.center)
 
             Text("Choose how much you're willing to donate each time you exceed your daily app limit.")
-                .font(.body)
+                .font(FontTheme.bodyFont)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 
@@ -23,11 +23,11 @@ struct DonationPriceSettingsView: View {
                     .padding(.horizontal)
 
                 Text(String(format: "$%.2f", donationPrice))
-                    .font(.title)
+                    .font(FontTheme.subtitleFont)
                     .padding(.top, 4)
 
                 Text("recommended\nfor beginners")
-                    .font(.caption)
+                    .font(FontTheme.bodyFont)
                     .multilineTextAlignment(.center)
                     .foregroundColor(.gray)
                     .scaleEffect(0.8)

--- a/DonationSliderView.swift
+++ b/DonationSliderView.swift
@@ -9,7 +9,7 @@ struct DonationSliderView: View {
             Slider(value: $amount, in: 0.5...5, step: 0.5)
             
             Text(String(format: "$%.2f", amount))
-                .font(.headline)
+                .font(FontTheme.subtitleFont)
                 .foregroundColor(.gray)
         }
     }

--- a/FontTheme.swift
+++ b/FontTheme.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// Provides a centralized set of fonts used throughout the app.
+enum FontTheme {
+    /// Bold title font for large headings.
+    static let titleFont = Font.system(size: 28, weight: .bold, design: .default)
+    /// Semibold font for subtitles and section headers.
+    static let subtitleFont = Font.system(size: 20, weight: .semibold, design: .default)
+    /// Semibold font sized for buttons.
+    static let buttonFont = Font.system(size: 18, weight: .semibold, design: .default)
+    /// Standard body text font.
+    static let bodyFont = Font.system(size: 16, weight: .regular, design: .default)
+}

--- a/InstallProfileInstructionsView.swift
+++ b/InstallProfileInstructionsView.swift
@@ -9,12 +9,12 @@ struct InstallProfileInstructionsView: View {
 
             VStack(spacing: 8) {
                 Text("Let’s Finish Setup")
-                    .font(.largeTitle)
+                    .font(FontTheme.titleFont)
                     .bold()
                     .multilineTextAlignment(.center)
 
                 Text("Just one step left: install the permission in Safari so we can enforce your screen time limits.")
-                    .font(.body)
+                    .font(FontTheme.bodyFont)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal)
             }
@@ -25,7 +25,7 @@ struct InstallProfileInstructionsView: View {
                 Text("3. Tap “Allow” and follow the prompts")
                 Text("4. Return to this app and tap Continue")
             }
-            .font(.title3) // 🔠 Larger font
+            .font(FontTheme.subtitleFont) // 🔠 Larger font
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.gray.opacity(0.1))

--- a/LimitSetterView.swift
+++ b/LimitSetterView.swift
@@ -13,13 +13,13 @@ struct LimitSetterView: View {
                 ForEach(apps, id: \.self) { app in
                     VStack(alignment: .leading) {
                         Text(app)
-                            .font(.headline)
+                            .font(FontTheme.subtitleFont)
                         Slider(value: Binding(
                             get: { Double(appLimits[app] ?? 30) },
                             set: { appLimits[app] = Int($0) }
                         ), in: 0...180, step: 5)
                         Text("Limit: \(appLimits[app] ?? 30) minutes")
-                            .font(.caption)
+                            .font(FontTheme.bodyFont)
                             .foregroundColor(.gray)
                     }
                     .padding(.vertical)

--- a/MainAppView.swift
+++ b/MainAppView.swift
@@ -27,7 +27,7 @@ struct MainAppView: View {
         ScrollView {
             VStack(spacing: 30) {
                 Text("Time Is Money")
-                    .font(.system(size: 34, weight: .heavy, design: .rounded))
+                    .font(FontTheme.titleFont)
                     .padding(.top, 20)
 
                 Button("Safe Time Settings") {

--- a/OnboardingView.swift
+++ b/OnboardingView.swift
@@ -46,12 +46,13 @@ private struct OnboardingPage: View {
 
             VStack(spacing: 12) {
                 Text(title)
-                    .font(.largeTitle.bold())
+                    .font(FontTheme.titleFont)
+                    .bold()
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity)
 
                 Text(subtitle)
-                    .font(.body)
+                    .font(FontTheme.bodyFont)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity)
                     .padding(.horizontal)

--- a/PaywallView.swift
+++ b/PaywallView.swift
@@ -12,12 +12,12 @@ struct PaywallView: View {
         NavigationView {
             VStack(spacing: 30) {
                 Text("Time’s Up for \(appName)")
-                    .font(.largeTitle)
+                    .font(FontTheme.titleFont)
                     .bold()
                     .multilineTextAlignment(.center)
 
                 Text("You’ve reached your limit. To keep going, donate an amount below to unlock more time.")
-                    .font(.body)
+                    .font(FontTheme.bodyFont)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal)
 
@@ -73,14 +73,14 @@ struct DonationProductButton: View {
             HStack {
                 VStack(alignment: .leading) {
                     Text(product.displayName)
-                        .font(.headline)
+                        .font(FontTheme.subtitleFont)
                     Text(product.description)
-                        .font(.subheadline)
+                        .font(FontTheme.bodyFont)
                         .foregroundColor(.gray)
                 }
                 Spacer()
                 Text(product.displayPrice)
-                    .font(.headline)
+                    .font(FontTheme.subtitleFont)
             }
             .padding()
         }

--- a/PrimaryButtonStyle.swift
+++ b/PrimaryButtonStyle.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct PrimaryButtonStyle: ViewModifier {
     func body(content: Content) -> some View {
         content
+            .font(FontTheme.buttonFont)
             .fontWeight(.bold)
             .foregroundColor(.white)
             .padding()

--- a/SafeTimeSettingsView.swift
+++ b/SafeTimeSettingsView.swift
@@ -59,7 +59,7 @@ struct SafeTimeSettingsView: View {
                 if !safeTimeManager.canUpdateSafeTime {
                     // Show a notice when edits are locked
                     Text("You can update your safe time again in \(safeTimeManager.remainingDays) days. Changes are allowed once every 7 days.")
-                        .font(.footnote)
+                        .font(FontTheme.bodyFont)
                         .foregroundColor(.gray)
                 }
             }

--- a/SessionView.swift
+++ b/SessionView.swift
@@ -22,9 +22,10 @@ struct SessionView: View {
 
             VStack(spacing: 20) {
                 Text("You're in a session for")
-                    .font(.title2)
+                    .font(FontTheme.subtitleFont)
                 Text(appName)
-                    .font(.largeTitle.bold())
+                    .font(FontTheme.titleFont)
+                    .bold()
 
                 Text("Time used: \(timeUsed) / \(limit) min")
                     .padding(.top)

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -35,7 +35,7 @@ struct SettingsView: View {
                 Section(header: Text("About")) {
                     Text("Time is Money v1.0")
                     Text("75% of profits go to charity.")
-                        .font(.footnote)
+                        .font(FontTheme.bodyFont)
                         .foregroundColor(.gray)
                 }
             }


### PR DESCRIPTION
## Summary
- add `FontTheme` to centralize SF Pro fonts
- use `FontTheme` across all views
- update `PrimaryButtonStyle` to apply `buttonFont`

## Testing
- `swift build` *(fails: no Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6861ddac34988324acaffd0685ec3ce7