### PR TITLE
Add ColorTheme

### DIFF
--- a/ColorTheme.swift
+++ b/ColorTheme.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// Provides a centralized set of colors used throughout the app.
+enum ColorTheme {
+    /// Dark background color matching Apple Watch style (#000000).
+    static let backgroundBlack = Color.black
+    /// Primary text color for readability (#FFFFFF).
+    static let textWhite = Color.white
+    /// Accent orange used for highlights (#FF9500).
+    static let accentOrange = Color(red: 1, green: 149/255, blue: 0)
+    /// Dark gray for button backgrounds (#1C1C1E).
+    static let buttonDarkGray = Color(red: 28/255, green: 28/255, blue: 30/255)
+}

--- a/Time_is_MoneyApp.swift
+++ b/Time_is_MoneyApp.swift
@@ -9,6 +9,7 @@ struct Time_is_MoneyApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .accentColor(ColorTheme.accentOrange)
         }
     }
 }


### PR DESCRIPTION
## Summary
- create `ColorTheme` to centralize watch style colors
- apply orange accent color globally

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_686f0ff5cb8083248a76ef5264e92a69