### PR TITLE
Update onboarding and titles colors

### DIFF
--- a/ActivationScreen.swift
+++ b/ActivationScreen.swift
@@ -9,6 +9,7 @@ struct ActivationScreen: View {
             VStack(spacing: 26) {
                 Text("Let’s Finish Setup")
                     .font(FontTheme.titleFont)
+                    .foregroundColor(ColorTheme.textWhite)
                     .multilineTextAlignment(.center)
 
                 Text("Just one step left: install the permission from Safari so we can enforce screen time limits.")

--- a/AppLimitSettingsView.swift
+++ b/AppLimitSettingsView.swift
@@ -21,6 +21,7 @@ struct AppLimitSettingsView: View {
             VStack(spacing: 20) {
             Text("Set Daily Limits")
                 .font(FontTheme.titleFont)
+                .foregroundColor(ColorTheme.textWhite)
                 .bold()
                 .padding(.top)
 

--- a/DonationPriceSettingsView.swift
+++ b/DonationPriceSettingsView.swift
@@ -14,6 +14,7 @@ struct DonationPriceSettingsView: View {
             VStack(spacing: 30) {
             Text("Set Donation Price")
                 .font(FontTheme.titleFont)
+                .foregroundColor(ColorTheme.textWhite)
                 .bold()
                 .multilineTextAlignment(.center)
 

--- a/InstallProfileInstructionsView.swift
+++ b/InstallProfileInstructionsView.swift
@@ -14,6 +14,7 @@ struct InstallProfileInstructionsView: View {
             VStack(spacing: 8) {
                 Text("Let’s Finish Setup")
                     .font(FontTheme.titleFont)
+                    .foregroundColor(ColorTheme.textWhite)
                     .bold()
                     .multilineTextAlignment(.center)
 

--- a/MainAppView.swift
+++ b/MainAppView.swift
@@ -24,6 +24,7 @@ struct MainAppView: View {
             VStack(spacing: 24) {
                 Text("Time Is Money")
                     .font(FontTheme.titleFont)
+                    .foregroundColor(ColorTheme.textWhite)
                     .bold()
                     .padding(.top, 24)
 

--- a/OnboardingView.swift
+++ b/OnboardingView.swift
@@ -52,12 +52,14 @@ private struct OnboardingPage: View {
             VStack(spacing: 12) {
                 Text(title)
                     .font(FontTheme.titleFont)
+                    .foregroundColor(ColorTheme.textWhite)
                     .bold()
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity)
 
                 Text(subtitle)
-                    .font(FontTheme.bodyFont)
+                    .font(FontTheme.subtitleFont)
+                    .foregroundColor(ColorTheme.accentOrange)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity)
                     .padding(.horizontal)

--- a/PaywallView.swift
+++ b/PaywallView.swift
@@ -17,6 +17,7 @@ struct PaywallView: View {
             VStack(spacing: 30) {
                 Text("Time’s Up for \(appName)")
                     .font(FontTheme.titleFont)
+                    .foregroundColor(ColorTheme.textWhite)
                     .bold()
                     .multilineTextAlignment(.center)
 

--- a/SessionView.swift
+++ b/SessionView.swift
@@ -19,8 +19,10 @@ struct SessionView: View {
             VStack(spacing: 20) {
                 Text("You're in a session for")
                     .font(FontTheme.subtitleFont)
+                    .foregroundColor(ColorTheme.accentOrange)
                 Text(appName)
                     .font(FontTheme.titleFont)
+                    .foregroundColor(ColorTheme.textWhite)
                     .bold()
 
                 Text("Time used: \(timeUsed) / \(limit) min")


### PR DESCRIPTION
## Summary
- unify title text color across screens using `ColorTheme.textWhite`
- highlight subtitles in onboarding with `ColorTheme.accentOrange`
- tweak session subtitle color to match accent

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686f1aa18dac8324a84b24a79dff9689