### PR TITLE
Update button style to dark gray

### DIFF
--- a/LimitSetterView.swift
+++ b/LimitSetterView.swift
@@ -37,6 +37,7 @@ struct LimitSetterView: View {
                         saveAppLimits()
                         HapticManager.success()
                     }
+                    .primaryButtonStyle()
                 }
             }
             }

--- a/PaywallView.swift
+++ b/PaywallView.swift
@@ -38,7 +38,6 @@ struct PaywallView: View {
                     dismiss()
                 }
                 .primaryButtonStyle()
-                .foregroundColor(.red)
             }
             .padding()
             .navigationBarTitleDisplayMode(.inline)

--- a/PrimaryButtonStyle.swift
+++ b/PrimaryButtonStyle.swift
@@ -9,13 +9,7 @@ struct PrimaryButtonStyle: ViewModifier {
             .foregroundColor(.white)
             .padding()
             .frame(maxWidth: .infinity)
-            .background(
-                LinearGradient(
-                    colors: [Color.blue, Color.purple],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-            )
+            .background(ColorTheme.buttonDarkGray)
             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             .shadow(color: Color.black.opacity(0.2), radius: 4, x: 0, y: 2)
     }

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -50,6 +50,7 @@ struct SettingsView: View {
                         triggerLightHaptic()
                         isPresented = false
                     }
+                    .primaryButtonStyle()
                 }
             }
         }

--- a/WeekdayCalendarPicker.swift
+++ b/WeekdayCalendarPicker.swift
@@ -20,8 +20,10 @@ struct WeekdayCalendarPicker: View {
                     Text(symbol)
                         .frame(maxWidth: .infinity, minHeight: 32)
                         .padding(4)
-                        .background(selection.contains(day) ? Color.blue.opacity(0.2) : Color.clear)
-                        .cornerRadius(6)
+                        .background(selection.contains(day) ? ColorTheme.accentOrange : ColorTheme.buttonDarkGray)
+                        .foregroundColor(.white)
+                        .cornerRadius(12)
+                        .shadow(color: .black.opacity(0.2), radius: 2, x: 0, y: 1)
                 }
                 .buttonStyle(.plain)
                 .disabled(disabled)


### PR DESCRIPTION
## Summary
- change `PrimaryButtonStyle` to use `ColorTheme.buttonDarkGray`
- style weekday picker buttons and toolbar buttons
- remove outdated color overrides

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_687045b14464832497847db98fc2bf25