### PR TITLE
Introduce FontTheme and apply across views

### DIFF
--- a/ActivationScreen.swift
+++ b/ActivationScreen.swift
@@ -8,12 +8,12 @@ struct ActivationScreen: View {
                 .ignoresSafeArea()
             VStack(spacing: 26) {
                 Text("Let’s Finish Setup")
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.titleFont)
                     .foregroundColor(ColorTheme.textWhite)
                     .multilineTextAlignment(.center)
 
                 Text("Just one step left: install the permission from Safari so we can enforce screen time limits.")
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.bodyFont)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal)
 
@@ -23,7 +23,7 @@ struct ActivationScreen: View {
                     Text("3. Tap 'Allow' when prompted")
                     Text("4. Go to Settings > Profile Downloaded to install")
                 }
-                .font(Font.system(size: 24, weight: .bold, design: .default))
+                .font(FontTheme.bodyFont)
                 .padding()
                 .background(.ultraThinMaterial)
                 .cornerRadius(12)

--- a/AppCardView.swift
+++ b/AppCardView.swift
@@ -44,7 +44,7 @@ struct AppCardView: View {
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(appName)
-                        .font(Font.system(size: 24, weight: .bold, design: .default))
+                        .font(FontTheme.subtitleFont)
                     ProgressView(value: percentUsed)
                         .progressViewStyle(LinearProgressViewStyle(tint: usageColor))
                 }

--- a/AppLimitSettingsView.swift
+++ b/AppLimitSettingsView.swift
@@ -20,7 +20,7 @@ struct AppLimitSettingsView: View {
 
             VStack(spacing: 20) {
             Text("Set Daily Limits")
-                .font(Font.system(size: 24, weight: .bold, design: .default))
+                .font(FontTheme.titleFont)
                 .foregroundColor(ColorTheme.textWhite)
                 .bold()
                 .padding(.top)
@@ -29,7 +29,7 @@ struct AppLimitSettingsView: View {
                 ForEach(appLimits.keys.sorted(), id: \.self) { app in
                     VStack(alignment: .leading) {
                         Text(app)
-                            .font(Font.system(size: 24, weight: .bold, design: .default))
+                            .font(FontTheme.subtitleFont)
 
                         Slider(value: Binding(
                             get: { Double(appLimits[app] ?? 0) },
@@ -37,7 +37,7 @@ struct AppLimitSettingsView: View {
                         ), in: 0...120, step: 5)
 
                         Text("\(appLimits[app] ?? 0) minutes")
-                            .font(Font.system(size: 24, weight: .bold, design: .default))
+                            .font(FontTheme.bodyFont)
                             .foregroundColor(.gray)
                     }
                     .padding(.vertical, 5)

--- a/DonationPriceSettingsView.swift
+++ b/DonationPriceSettingsView.swift
@@ -13,13 +13,13 @@ struct DonationPriceSettingsView: View {
 
             VStack(spacing: 30) {
             Text("Set Donation Price")
-                .font(Font.system(size: 24, weight: .bold, design: .default))
+                .font(FontTheme.titleFont)
                 .foregroundColor(ColorTheme.textWhite)
                 .bold()
                 .multilineTextAlignment(.center)
 
             Text("Choose how much you're willing to donate each time you exceed your daily app limit.")
-                .font(Font.system(size: 24, weight: .bold, design: .default))
+                .font(FontTheme.bodyFont)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
 
@@ -28,11 +28,11 @@ struct DonationPriceSettingsView: View {
                     .padding(.horizontal)
 
                 Text(String(format: "$%.2f", donationPrice))
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.subtitleFont)
                     .padding(.top, 4)
 
                 Text("recommended\nfor beginners")
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.bodyFont)
                     .multilineTextAlignment(.center)
                     .foregroundColor(.gray)
                     .scaleEffect(0.8)

--- a/DonationSliderView.swift
+++ b/DonationSliderView.swift
@@ -9,7 +9,7 @@ struct DonationSliderView: View {
             Slider(value: $amount, in: 0.5...5, step: 0.5)
             
             Text(String(format: "$%.2f", amount))
-                .font(Font.system(size: 24, weight: .bold, design: .default))
+                .font(FontTheme.subtitleFont)
                 .foregroundColor(.gray)
         }
     }

--- a/FontTheme.swift
+++ b/FontTheme.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Provides a centralized set of fonts used throughout the app.
-enum FontTheme {
+struct FontTheme {
     /// Bold title font for large headings.
     static let titleFont = Font.system(size: 28, weight: .bold, design: .default)
     /// Semibold font for subtitles and section headers.

--- a/InstallProfileInstructionsView.swift
+++ b/InstallProfileInstructionsView.swift
@@ -13,13 +13,13 @@ struct InstallProfileInstructionsView: View {
 
             VStack(spacing: 8) {
                 Text("Let’s Finish Setup")
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.titleFont)
                     .foregroundColor(ColorTheme.textWhite)
                     .bold()
                     .multilineTextAlignment(.center)
 
                 Text("Just one step left: install the permission in Safari so we can enforce your screen time limits.")
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.bodyFont)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal)
             }
@@ -30,7 +30,7 @@ struct InstallProfileInstructionsView: View {
                 Text("3. Tap “Allow” and follow the prompts")
                 Text("4. Return to this app and tap Continue")
             }
-            .font(Font.system(size: 24, weight: .bold, design: .default)) // 🔠 Larger font
+            .font(FontTheme.bodyFont) // 🔠 Larger font
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.gray.opacity(0.1))

--- a/LimitSetterView.swift
+++ b/LimitSetterView.swift
@@ -17,13 +17,13 @@ struct LimitSetterView: View {
                 ForEach(apps, id: \.self) { app in
                     VStack(alignment: .leading) {
                         Text(app)
-                            .font(Font.system(size: 24, weight: .bold, design: .default))
+                            .font(FontTheme.subtitleFont)
                         Slider(value: Binding(
                             get: { Double(appLimits[app] ?? 30) },
                             set: { appLimits[app] = Int($0) }
                         ), in: 0...180, step: 5)
                         Text("Limit: \(appLimits[app] ?? 30) minutes")
-                            .font(Font.system(size: 24, weight: .bold, design: .default))
+                            .font(FontTheme.bodyFont)
                             .foregroundColor(.gray)
                     }
                     .padding(.vertical)

--- a/MainAppView.swift
+++ b/MainAppView.swift
@@ -23,7 +23,7 @@ struct MainAppView: View {
             ScrollView {
             VStack(spacing: 24) {
                 Text("Time Is Money")
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.titleFont)
                     .foregroundColor(ColorTheme.textWhite)
                     .bold()
                     .padding(.top, 24)

--- a/OnboardingView.swift
+++ b/OnboardingView.swift
@@ -51,14 +51,14 @@ private struct OnboardingPage: View {
 
             VStack(spacing: 12) {
                 Text(title)
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.titleFont)
                     .foregroundColor(ColorTheme.textWhite)
                     .bold()
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity)
 
                 Text(subtitle)
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.subtitleFont)
                     .foregroundColor(ColorTheme.accentOrange)
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: .infinity)

--- a/PaywallView.swift
+++ b/PaywallView.swift
@@ -16,13 +16,13 @@ struct PaywallView: View {
             NavigationView {
             VStack(spacing: 30) {
                 Text("Time’s Up for \(appName)")
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.titleFont)
                     .foregroundColor(ColorTheme.textWhite)
                     .bold()
                     .multilineTextAlignment(.center)
 
                 Text("You’ve reached your limit. To keep going, donate an amount below to unlock more time.")
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.bodyFont)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal)
 
@@ -77,14 +77,14 @@ struct DonationProductButton: View {
             HStack {
                 VStack(alignment: .leading) {
                     Text(product.displayName)
-                        .font(Font.system(size: 24, weight: .bold, design: .default))
+                        .font(FontTheme.subtitleFont)
                     Text(product.description)
-                        .font(Font.system(size: 24, weight: .bold, design: .default))
+                        .font(FontTheme.bodyFont)
                         .foregroundColor(.gray)
                 }
                 Spacer()
                 Text(product.displayPrice)
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.subtitleFont)
             }
             .padding()
         }

--- a/PrimaryButtonStyle.swift
+++ b/PrimaryButtonStyle.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct PrimaryButtonStyle: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .font(Font.system(size: 24, weight: .bold, design: .default))
+            .font(FontTheme.buttonFont)
             .fontWeight(.bold)
             .foregroundColor(.white)
             .padding()

--- a/SafeTimeSettingsView.swift
+++ b/SafeTimeSettingsView.swift
@@ -63,7 +63,7 @@ struct SafeTimeSettingsView: View {
                 if !safeTimeManager.canUpdateSafeTime {
                     // Show a notice when edits are locked
                     Text("You can update your safe time again in \(safeTimeManager.remainingDays) days. Changes are allowed once every 7 days.")
-                        .font(Font.system(size: 24, weight: .bold, design: .default))
+                        .font(FontTheme.bodyFont)
                         .foregroundColor(.gray)
                 }
             }

--- a/SessionView.swift
+++ b/SessionView.swift
@@ -18,10 +18,10 @@ struct SessionView: View {
 
             VStack(spacing: 20) {
                 Text("You're in a session for")
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.subtitleFont)
                     .foregroundColor(ColorTheme.accentOrange)
                 Text(appName)
-                    .font(Font.system(size: 24, weight: .bold, design: .default))
+                    .font(FontTheme.titleFont)
                     .foregroundColor(ColorTheme.textWhite)
                     .bold()
 

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -39,7 +39,7 @@ struct SettingsView: View {
                 Section(header: Text("About")) {
                     Text("Time is Money v1.0")
                     Text("75% of profits go to charity.")
-                        .font(Font.system(size: 24, weight: .bold, design: .default))
+                        .font(FontTheme.bodyFont)
                         .foregroundColor(.gray)
                 }
             }


### PR DESCRIPTION
## Summary
- add `FontTheme` struct defining title, subtitle, button and body fonts
- reference `FontTheme` in all SwiftUI views and modifiers

## Testing
- `swiftc --version`

------
https://chatgpt.com/codex/tasks/task_e_68704719fa388324bc1c650c383cbba6