### PR TITLE
Apply global dark theme

### DIFF
--- a/PrimaryButtonStyle.swift
+++ b/PrimaryButtonStyle.swift
@@ -6,7 +6,7 @@ struct PrimaryButtonStyle: ViewModifier {
         content
             .font(FontTheme.buttonFont)
             .fontWeight(.bold)
-            .foregroundColor(.white)
+            .foregroundColor(ColorTheme.textWhite)
             .padding()
             .frame(maxWidth: .infinity)
             .background(ColorTheme.buttonDarkGray)

--- a/SafeTimeSettingsView.swift
+++ b/SafeTimeSettingsView.swift
@@ -37,7 +37,9 @@ struct SafeTimeSettingsView: View {
             NavigationView {
             Form {
                 // Pick the hours during which usage is free
-                Section(header: Text("Select your Safe Time Window")) {
+                Section(header: Text("Select your Safe Time Window")
+                    .font(FontTheme.subtitleFont)
+                    .foregroundColor(ColorTheme.accentOrange)) {
                     DatePicker("Start Time", selection: $selectedStart, displayedComponents: .hourAndMinute)
                         .disabled(!safeTimeManager.canUpdateSafeTime)
                     DatePicker("End Time", selection: $selectedEnd, displayedComponents: .hourAndMinute)
@@ -45,7 +47,9 @@ struct SafeTimeSettingsView: View {
                 }
 
                 // Choose which weekdays the window is active using a compact calendar
-                Section(header: Text("Active Days")) {
+                Section(header: Text("Active Days")
+                    .font(FontTheme.subtitleFont)
+                    .foregroundColor(ColorTheme.accentOrange)) {
                     WeekdayCalendarPicker(selection: $selectedDays,
                                           disabled: !safeTimeManager.canUpdateSafeTime)
                 }

--- a/SettingsView.swift
+++ b/SettingsView.swift
@@ -13,7 +13,9 @@ struct SettingsView: View {
 
             NavigationView {
             List {
-                Section(header: Text("Reset")) {
+                Section(header: Text("Reset")
+                    .font(FontTheme.subtitleFont)
+                    .foregroundColor(ColorTheme.accentOrange)) {
                     Button("Reset All App Limits") {
                         triggerLightHaptic()
                         onResetLimits()
@@ -28,7 +30,9 @@ struct SettingsView: View {
                     .primaryButtonStyle()
                 }
 
-                Section(header: Text("Onboarding")) {
+                Section(header: Text("Onboarding")
+                    .font(FontTheme.subtitleFont)
+                    .foregroundColor(ColorTheme.accentOrange)) {
                     Button("See Onboarding Again") {
                         triggerLightHaptic()
                         onRecallOnboarding()
@@ -36,7 +40,9 @@ struct SettingsView: View {
                     .primaryButtonStyle()
                 }
 
-                Section(header: Text("About")) {
+                Section(header: Text("About")
+                    .font(FontTheme.subtitleFont)
+                    .foregroundColor(ColorTheme.accentOrange)) {
                     Text("Time is Money v1.0")
                     Text("75% of profits go to charity.")
                         .font(FontTheme.bodyFont)

--- a/WeekdayCalendarPicker.swift
+++ b/WeekdayCalendarPicker.swift
@@ -21,7 +21,7 @@ struct WeekdayCalendarPicker: View {
                         .frame(maxWidth: .infinity, minHeight: 32)
                         .padding(4)
                         .background(selection.contains(day) ? ColorTheme.accentOrange : ColorTheme.buttonDarkGray)
-                        .foregroundColor(.white)
+                        .foregroundColor(ColorTheme.textWhite)
                         .cornerRadius(12)
                         .shadow(color: .black.opacity(0.2), radius: 2, x: 0, y: 1)
                 }


### PR DESCRIPTION
## Summary
- update button text color helper
- use white text in weekday picker
- style section headers in settings and safe time screens

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68704bb452608324968237e0f8dac20c