### PR TITLE
Apply white text color to app names

### DIFF
--- a/AppCardView.swift
+++ b/AppCardView.swift
@@ -45,6 +45,7 @@ struct AppCardView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Text(appName)
                         .font(FontTheme.subtitleFont)
+                        .foregroundColor(.white)
                     ProgressView(value: percentUsed)
                         .progressViewStyle(LinearProgressViewStyle(tint: usageColor))
                 }

--- a/AppLimitSettingsView.swift
+++ b/AppLimitSettingsView.swift
@@ -31,6 +31,7 @@ struct AppLimitSettingsView: View {
                         VStack(alignment: .leading) {
                             Text(app)
                                 .font(FontTheme.subtitleFont)
+                                .foregroundColor(.white)
 
                             Slider(value: Binding(
                                 get: { Double(appLimits[app] ?? 0) },

--- a/LimitSetterView.swift
+++ b/LimitSetterView.swift
@@ -18,6 +18,7 @@ struct LimitSetterView: View {
                     VStack(alignment: .leading) {
                         Text(app)
                             .font(FontTheme.subtitleFont)
+                            .foregroundColor(.white)
                         Slider(value: Binding(
                             get: { Double(appLimits[app] ?? 30) },
                             set: { appLimits[app] = Int($0) }

--- a/SessionView.swift
+++ b/SessionView.swift
@@ -22,7 +22,7 @@ struct SessionView: View {
                     .foregroundColor(ColorTheme.accentOrange)
                 Text(appName)
                     .font(FontTheme.titleFont)
-                    .foregroundColor(ColorTheme.textWhite)
+                    .foregroundColor(.white)
                     .bold()
 
                 Text("Time used: \(timeUsed) / \(limit) min")


### PR DESCRIPTION
## Summary
- show app names in white on dark backgrounds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68759ae248108324961ebad17f31231c