### PR TITLE
Ensure app names appear in white

### DIFF
--- a/PaywallView.swift
+++ b/PaywallView.swift
@@ -17,7 +17,7 @@ struct PaywallView: View {
                 VStack(spacing: 30) {
                     Text("Time’s Up for \(appName)")
                         .font(FontTheme.titleFont)
-                        .foregroundColor(ColorTheme.textWhite)
+                        .foregroundColor(.white)
                         .bold()
                         .multilineTextAlignment(.center)
 


### PR DESCRIPTION
## Summary
- update paywall text color to hardcode white

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_68759c6b9c988324bf9ccd7be7eef7d5